### PR TITLE
iptables: Remove --to-ports from MASQUERADE rules

### DIFF
--- a/server/fw_util_iptables.c
+++ b/server/fw_util_iptables.c
@@ -1363,8 +1363,7 @@ static void snat_rule(const fko_srv_options_t * const opts,
         {
             /* Using MASQUERADE */
             snat_chain = &(opts->fw_config->chain[IPT_MASQUERADE_ACCESS]);
-            snprintf(snat_target, SNAT_TARGET_BUFSIZE-1,
-                "--to-ports %i", fst_port);
+            snprintf(snat_target, SNAT_TARGET_BUFSIZE-1, " ");
         }
         else if((opts->config[CONF_SNAT_TRANSLATE_IP] != NULL)
             && is_valid_ipv4_addr(opts->config[CONF_SNAT_TRANSLATE_IP]))
@@ -1379,8 +1378,7 @@ static void snat_rule(const fko_srv_options_t * const opts,
         {
             /* Using MASQUERADE */
             snat_chain = &(opts->fw_config->chain[IPT_MASQUERADE_ACCESS]);
-            snprintf(snat_target, SNAT_TARGET_BUFSIZE-1,
-                "--to-ports %i", fst_port);
+            snprintf(snat_target, SNAT_TARGET_BUFSIZE-1, " ");
         }
 
         memset(rule_buf, 0, CMD_BUFSIZE);


### PR DESCRIPTION
Removed `--to-ports` from MASQUERADE rules of iptables to accept multiple sessions when using DNAT.

`--to-ports` is to be used to specify a port range for masquerading.
https://manpages.debian.org/bullseye/iptables/iptables-extensions.8.en.html#MASQUERADE

The latest implementation specifies only one port for `--to-ports` provided by `fst_port`, which means masquerading always tries to use the same port for its source port.
Therefore, another session to the same DNAT destination host will not be able to be established unless the previous one is closed.

When a gateway is placed in front of SDP Controller with DNAT, the gateway cannot foward connections from multiple SDP clients.